### PR TITLE
Fix: Correctly propagate model selection options in GMITurnInput metadata

### DIFF
--- a/src/api/AgentOSOrchestrator.ts
+++ b/src/api/AgentOSOrchestrator.ts
@@ -870,7 +870,7 @@ export class AgentOSOrchestrator {
     const gmiInputMetadata: Record<string, any> = {
         gmiId: gmi.getGMIId(),
         // Pass relevant options to GMI if it needs them
-        processingOptions: options,
+        options: options,
         // User API keys are handled by GMIManager when fetching/creating GMI,
         // but can be passed in metadata if GMI needs them per-turn for some reason.
         userApiKeys: input.userApiKeys,


### PR DESCRIPTION
This PR addresses a bug in the AgentOSOrchestrator where model selection options (e.g., preferredModelId) provided in the AgentOSInput were not being correctly propagated to the
  GMITurnInput's metadata object. This led to the GMI component failing to determine the modelId for LLM calls, resulting in a **GMIError:** Could not determine modelId for LLM call.

  **Detailed Explanation of the Change:**
  The AgentOSOrchestrator is responsible for constructing the GMITurnInput from the AgentOSInput. Within the private constructGMITurnInput(...) method in src/api/AgentOSOrchestrator.ts,
  the options object (containing properties like preferredModelId) from the AgentOSInput was incorrectly assigned to a property named processingOptions within the gmiInputMetadata
  object.

  The GMI component, however, expects these model selection options to be directly under a property named options within the GMITurnInput.metadata object. This mismatch in property names
  caused the GMI to fail when attempting to retrieve the modelId.

  The fix involves modifying the gmiInputMetadata construction within constructGMITurnInput to correctly assign the options object to the options property:

  **Before (Incorrect):**

   
```typescript
1     const gmiInputMetadata: Record<string, any> = {
   2         gmiId: gmi.getGMIId(),
   3         // ... other metadata properties
   4         processingOptions: options, // This was the incorrect assignment
   5         // ... other modelSelectionOverrides and personaStateOverrides
   6     };
```

  **After (Correct):**

```typescript
   1     const gmiInputMetadata: Record<string, any> = {
   2         gmiId: gmi.getGMIId(),
   3         // ... other metadata properties
   4         options: options, // Corrected assignment
   5         // ... other modelSelectionOverrides and personaStateOverrides
   6     };
```


  **Impact of the Change:**
  This correction ensures that model selection preferences specified in AgentOSInput (e.g., via agent.processRequest({ options: { preferredModelId: 'gpt-4o' } })) are now accurately
  passed through the orchestration layer to the GMI. This resolves the GMIError: Could not determine modelId for LLM call. and allows the GMI to correctly utilize the intended LLM model
  for its operations. This is purely a bug fix that aligns internal data propagation with expected component interfaces.

  **Testing:**
  This change was validated by running an example application that depends on [@framers/agentos](https://www.npmjs.com/package/@framers/agentos). After building the modified agentos package and linking it to the example application, the
  application successfully initialized and executed an LLM call using the specified model, producing a coherent response.

## Summary by Sourcery

Bug Fixes:
- Ensure model selection options from AgentOSInput are exposed under the expected options field in GMITurnInput metadata so GMI can determine the LLM model ID.