### PR TITLE
docs(spec+plan): session-aware structured output for agent.session.send

### DIFF
--- a/docs/superpowers/plans/2026-04-26-session-structured-output-plan.md
+++ b/docs/superpowers/plans/2026-04-26-session-structured-output-plan.md
@@ -1,0 +1,777 @@
+# Session-aware structured output — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Add an optional `responseSchema` parameter to `agent.session.send()` that routes through the provider's native structured-output API (OpenAI `json_schema`, Anthropic forced tool-use, Gemini `responseSchema`) while preserving session memory.
+
+**Architecture:** Backwards-compat overload on `AgentSession.send`. New thin provider-format adapter (`structuredOutputFormat.ts`) maps a Zod schema + provider id to the per-provider payload shape. Each provider (`OpenAIProvider`, `AnthropicProvider`, `GeminiProvider`) routes its `responseFormat` payload to the right native API surface.
+
+**Tech Stack:** TypeScript, Zod, agentos's existing `lowerZodToJsonSchema` lowering, node:test for tests.
+
+**Spec:** [`docs/superpowers/specs/2026-04-26-session-structured-output-design.md`](../specs/2026-04-26-session-structured-output-design.md).
+
+**Working directory:** Always `cd /Users/johnn/Documents/git/voice-chat-assistant/packages/agentos`.
+
+**Concurrent state caveat:** agentos working tree has uncommitted changes in `src/emergent/`, `src/memory/`, `src/memory-router/`, etc. None overlap the files this plan touches. Stage explicit file paths only — no `git add -A`.
+
+---
+
+## File map
+
+**Created:**
+- `src/core/llm/providers/structuredOutputFormat.ts` — provider-format adapter
+- `src/api/__tests__/agent.session.send.structured.test.ts`
+- `src/core/llm/providers/__tests__/structuredOutputFormat.test.ts`
+- `src/core/llm/providers/implementations/__tests__/AnthropicProvider.structured.test.ts`
+- `src/core/llm/providers/implementations/__tests__/GeminiProvider.structured.test.ts`
+
+**Modified:**
+- `src/api/agent.ts` — overload + impl on `AgentSession.send`; export `SessionSendOptions` + `SessionSendStructuredResult`
+- `src/api/index.ts` — re-export new public types
+- `src/core/llm/providers/IProvider.ts` — tighten `responseFormat` type
+- `src/core/llm/providers/implementations/AnthropicProvider.ts` — forced tool-use branch
+- `src/core/llm/providers/implementations/GeminiProvider.ts` — `responseSchema` branch
+- `src/core/llm/providers/implementations/__tests__/OpenAIProvider.test.ts` — extend with json_schema passthrough test (existing test file)
+
+**Read-only references:**
+- `src/api/generateText.ts:338` — `_responseFormat` declaration
+- `src/api/generateText.ts:931` — provider call passthrough
+- `src/orchestration/compiler/SchemaLowering.ts:38` — `lowerZodToJsonSchema`
+
+---
+
+## Task 1: Provider-format adapter + tests
+
+**Files:**
+- Create: `src/core/llm/providers/structuredOutputFormat.ts`
+- Create: `src/core/llm/providers/__tests__/structuredOutputFormat.test.ts`
+
+- [ ] **Step 1.1: Implement `buildResponseFormat`**
+
+```ts
+// src/core/llm/providers/structuredOutputFormat.ts
+import type { ZodType } from 'zod';
+import { lowerZodToJsonSchema } from '../../../orchestration/compiler/SchemaLowering.js';
+
+export interface BuildResponseFormatInput {
+  provider: string;
+  schema: ZodType;
+  schemaName: string;
+}
+
+const NAME_RE = /[^a-zA-Z0-9_]/g;
+
+export function buildResponseFormat(
+  input: BuildResponseFormatInput,
+): Record<string, unknown> {
+  const jsonSchema = lowerZodToJsonSchema(input.schema);
+  const schemaName = input.schemaName.replace(NAME_RE, '_').slice(0, 64) || 'response';
+
+  switch (input.provider) {
+    case 'openai':
+      return {
+        type: 'json_schema',
+        json_schema: { name: schemaName, strict: true, schema: jsonSchema },
+      };
+    case 'anthropic':
+      return {
+        _agentosUseToolForStructuredOutput: true,
+        tool: { name: schemaName, input_schema: jsonSchema },
+      };
+    case 'gemini':
+    case 'gemini-cli':
+      return {
+        type: 'json_object',
+        _gemini: { responseSchema: jsonSchema },
+      };
+    case 'openrouter':
+    default:
+      return { type: 'json_object' };
+  }
+}
+```
+
+- [ ] **Step 1.2: Tests**
+
+```ts
+// src/core/llm/providers/__tests__/structuredOutputFormat.test.ts
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { z } from 'zod';
+import { buildResponseFormat } from '../structuredOutputFormat.js';
+
+const schema = z.object({ a: z.string(), b: z.number() });
+
+test('openai returns json_schema with strict=true and sanitized name', () => {
+  const r = buildResponseFormat({ provider: 'openai', schema, schemaName: 'My.Schema' });
+  assert.equal((r as any).type, 'json_schema');
+  assert.equal((r as any).json_schema.name, 'My_Schema');
+  assert.equal((r as any).json_schema.strict, true);
+  assert.equal(typeof (r as any).json_schema.schema, 'object');
+});
+
+test('anthropic returns _agentosUseToolForStructuredOutput marker + tool shape', () => {
+  const r = buildResponseFormat({ provider: 'anthropic', schema, schemaName: 'X' });
+  assert.equal((r as any)._agentosUseToolForStructuredOutput, true);
+  assert.equal((r as any).tool.name, 'X');
+  assert.equal(typeof (r as any).tool.input_schema, 'object');
+});
+
+test('gemini returns json_object with _gemini.responseSchema', () => {
+  const r = buildResponseFormat({ provider: 'gemini', schema, schemaName: 'X' });
+  assert.equal((r as any).type, 'json_object');
+  assert.equal(typeof (r as any)._gemini.responseSchema, 'object');
+});
+
+test('openrouter degrades to json_object', () => {
+  const r = buildResponseFormat({ provider: 'openrouter', schema, schemaName: 'X' });
+  assert.deepEqual(r, { type: 'json_object' });
+});
+
+test('unknown provider degrades to json_object', () => {
+  const r = buildResponseFormat({ provider: 'unknown', schema, schemaName: 'X' });
+  assert.deepEqual(r, { type: 'json_object' });
+});
+
+test('schemaName is sanitized: replaces non-word chars with underscore, truncates to 64', () => {
+  const long = 'a'.repeat(80) + '!@#';
+  const r = buildResponseFormat({ provider: 'openai', schema, schemaName: long });
+  const n = (r as any).json_schema.name as string;
+  assert.equal(n.length, 64);
+  assert.match(n, /^[a-zA-Z0-9_]+$/);
+});
+
+test('empty/all-invalid schemaName falls back to "response"', () => {
+  const r = buildResponseFormat({ provider: 'openai', schema, schemaName: '!!!' });
+  assert.equal((r as any).json_schema.name, 'response');
+});
+```
+
+- [ ] **Step 1.3: Run tests**
+
+```bash
+cd /Users/johnn/Documents/git/voice-chat-assistant/packages/agentos
+npx tsc --noEmit  # verify type check
+npm test -- --grep "structuredOutputFormat" 2>&1 | tail -10
+```
+
+Expected: tsc clean. All 7 tests pass.
+
+- [ ] **Step 1.4: Em-dash sweep + commit**
+
+```bash
+perl -ne 'print "$ARGV:$.: $_" if /\x{2014}/' \
+  src/core/llm/providers/structuredOutputFormat.ts \
+  src/core/llm/providers/__tests__/structuredOutputFormat.test.ts && echo clean
+git add src/core/llm/providers/structuredOutputFormat.ts \
+        src/core/llm/providers/__tests__/structuredOutputFormat.test.ts
+git commit -m "feat(structured-output): provider-format adapter for session-aware schema enforcement
+
+New thin adapter `buildResponseFormat` that maps a Zod schema + provider id
+to the per-provider payload shape used by GenerateTextOptions._responseFormat.
+
+Provider matrix (April 2026):
+  - openai     → { type: 'json_schema', json_schema: { name, strict: true, schema } }
+  - anthropic  → { _agentosUseToolForStructuredOutput: true, tool: { name, input_schema } }
+  - gemini     → { type: 'json_object', _gemini: { responseSchema } }
+  - openrouter → { type: 'json_object' } (degrades; OpenRouter has no schema enforcement)
+  - default    → { type: 'json_object' } (best-effort for unknown providers)
+
+Schema name sanitization: non-[a-zA-Z0-9_] chars → underscore, max 64 chars,
+falls back to 'response' if all input chars were invalid. OpenAI's
+json_schema.name and Anthropic's tool name both have charset constraints
+this satisfies.
+
+Pure adapter; no provider behavior changes in this commit. Per-provider
+routing of the _agentosUseToolForStructuredOutput / _gemini fields lands
+in the next two commits."
+```
+
+---
+
+## Task 2: Tighten `IProvider.responseFormat` type
+
+**Files:**
+- Modify: `src/core/llm/providers/IProvider.ts`
+
+- [ ] **Step 2.1: Update the type**
+
+Open `src/core/llm/providers/IProvider.ts`. Find `responseFormat?:` (around line 137). Change from:
+
+```ts
+responseFormat?: { type: 'text' | 'json_object' | string };
+```
+
+to:
+
+```ts
+/**
+ * Response-format constraint for the provider call. Shape is
+ * provider-specific; the adapter at
+ * `src/core/llm/providers/structuredOutputFormat.ts` builds the right
+ * shape per provider given a Zod schema. Examples:
+ *   - OpenAI:    { type: 'json_object' }
+ *   - OpenAI:    { type: 'json_schema', json_schema: { name, strict, schema } }
+ *   - Anthropic: { _agentosUseToolForStructuredOutput: true, tool: {...} }
+ *   - Gemini:    { type: 'json_object', _gemini: { responseSchema } }
+ */
+responseFormat?:
+  | { type: 'text' | 'json_object' }
+  | { type: 'json_schema'; json_schema: { name: string; strict: boolean; schema: Record<string, unknown> } }
+  | Record<string, unknown>;
+```
+
+- [ ] **Step 2.2: Type-check**
+
+```bash
+npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: 0 errors. The new union is a superset; existing callers compile.
+
+- [ ] **Step 2.3: Em-dash sweep + commit**
+
+```bash
+perl -ne 'print "$ARGV:$.: $_" if /\x{2014}/' src/core/llm/providers/IProvider.ts && echo clean
+git add src/core/llm/providers/IProvider.ts
+git commit -m "chore(IProvider): tighten responseFormat type to admit json_schema shape
+
+The previous union ({ type: 'text' | 'json_object' | string }) accepted
+the json_schema shape via the catch-all string but didn't document or
+type the json_schema sub-fields. Tightens to a discriminated union plus
+a Record<string, unknown> escape hatch for provider-specific extras
+(Anthropic _agentosUseToolForStructuredOutput, Gemini _gemini, etc.).
+
+No behavior change. Existing { type: 'text' } and { type: 'json_object' }
+calls compile unchanged."
+```
+
+---
+
+## Task 3: AnthropicProvider forced tool-use
+
+**Files:**
+- Modify: `src/core/llm/providers/implementations/AnthropicProvider.ts`
+- Create: `src/core/llm/providers/implementations/__tests__/AnthropicProvider.structured.test.ts`
+
+- [ ] **Step 3.1: Add forced tool-use branch in request build**
+
+Locate the existing request build around `tool_choice` setup (current line 848). Right after the `tool_choice` branch, add:
+
+```ts
+// Schema-driven structured output via forced tool_use. The provider-format
+// adapter (structuredOutputFormat.ts) signals this mode by setting
+// _agentosUseToolForStructuredOutput on responseFormat. We add the
+// schema as a single tool and force the model to call it; the JSON-validated
+// input shows up in the response's tool_use block.
+const sf = options.responseFormat as
+  | { _agentosUseToolForStructuredOutput?: boolean; tool?: { name: string; input_schema: Record<string, unknown> } }
+  | undefined;
+if (sf?._agentosUseToolForStructuredOutput && sf.tool) {
+  payload.tools = [
+    { name: sf.tool.name, input_schema: sf.tool.input_schema },
+    ...(payload.tools ?? []),
+  ];
+  payload.tool_choice = { type: 'tool', name: sf.tool.name };
+}
+```
+
+- [ ] **Step 3.2: Add response-mapping branch**
+
+Find the existing tool_use response-mapping logic (search for `tool_use` in the file). After mapping content blocks, when the structured-output mode was active and a matching tool_use block exists, set the response's `text` field to `JSON.stringify(matchingBlock.input)` so generateText callers see a JSON-string result. This keeps the API surface uniform across providers (everything looks like `result.text` is a JSON string).
+
+```ts
+// (in mapApiToCompletionResponse or equivalent, after content blocks
+// are mapped to choices[].message.content)
+if (structuredOutputName) {  // captured from the request-build step
+  const toolBlock = apiResponse.content?.find(
+    (b): b is { type: 'tool_use'; name: string; input: unknown } =>
+      b.type === 'tool_use' && (b as any).name === structuredOutputName,
+  );
+  if (toolBlock) {
+    // Surface the structured payload as text so callers using
+    // result.text receive valid JSON; tool_use block remains in
+    // choices[0].message.tool_calls for callers that prefer it.
+    choice.message.content = JSON.stringify(toolBlock.input);
+  }
+}
+```
+
+The `structuredOutputName` is captured from `sf.tool.name` in the request-build step and threaded into the mapping function via closure or instance variable.
+
+- [ ] **Step 3.3: Tests**
+
+```ts
+// src/core/llm/providers/implementations/__tests__/AnthropicProvider.structured.test.ts
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { AnthropicProvider } from '../AnthropicProvider.js';
+
+test('AnthropicProvider: _agentosUseToolForStructuredOutput adds forced tool + tool_choice', async () => {
+  // Stub the underlying fetch / axios call to capture the payload sent.
+  // (Use the existing test scaffolding pattern from AnthropicProvider tests.)
+  // ... assert payload.tools[0].name === 'CommanderDecision'
+  // ... assert payload.tool_choice === { type: 'tool', name: 'CommanderDecision' }
+});
+
+test('AnthropicProvider: response with matching tool_use block surfaces input as text', async () => {
+  // Stub response with a tool_use content block named 'CommanderDecision'
+  // and input = { decision: 'X', rationale: 'Y' }.
+  // Assert result.choices[0].message.content === JSON.stringify({ decision: 'X', rationale: 'Y' }).
+});
+```
+
+(Test bodies follow the pattern of existing AnthropicProvider tests — the plan-executor consults the existing test file shape and replicates its scaffolding.)
+
+- [ ] **Step 3.4: Run tests + em-dash sweep + commit**
+
+```bash
+npx tsc --noEmit && \
+  npm test -- --grep "AnthropicProvider" 2>&1 | tail -10 && \
+  perl -ne 'print "$ARGV:$.: $_" if /\x{2014}/' \
+    src/core/llm/providers/implementations/AnthropicProvider.ts \
+    src/core/llm/providers/implementations/__tests__/AnthropicProvider.structured.test.ts && echo clean
+git add src/core/llm/providers/implementations/AnthropicProvider.ts \
+        src/core/llm/providers/implementations/__tests__/AnthropicProvider.structured.test.ts
+git commit -m "feat(AnthropicProvider): forced tool-use for schema-enforced structured output
+
+Anthropic doesn't have an OpenAI-style response_format with json_schema.
+The equivalent is forced tool_use: declare a single tool whose input_schema
+matches the desired output shape, then force tool_choice to that tool.
+The model returns a tool_use block whose input is JSON-validated against
+the schema by Anthropic's own enforcement.
+
+The provider-format adapter signals this mode via
+_agentosUseToolForStructuredOutput: true plus tool: { name, input_schema }.
+The provider:
+  - Adds the schema as a single forced tool to the payload
+  - Sets tool_choice: { type: 'tool', name }
+  - In response mapping, finds the matching tool_use block and surfaces
+    its input as JSON-string content on the choice's message, so
+    callers using result.text get valid JSON identical in shape to
+    OpenAI's json_schema response
+
+Existing tool-call flows (caller-provided tools, normal tool_choice)
+are unchanged; the schema mode only triggers when the marker is set."
+```
+
+---
+
+## Task 4: GeminiProvider responseSchema
+
+**Files:**
+- Modify: `src/core/llm/providers/implementations/GeminiProvider.ts`
+- Create: `src/core/llm/providers/implementations/__tests__/GeminiProvider.structured.test.ts`
+
+- [ ] **Step 4.1: Extend the responseFormat → generationConfig branch**
+
+Open `src/core/llm/providers/implementations/GeminiProvider.ts`. Find the existing branch (current line 732):
+
+```ts
+if (options.responseFormat?.type === 'json_object') {
+  generationConfig.responseMimeType = 'application/json';
+}
+```
+
+Extend to:
+
+```ts
+if (options.responseFormat?.type === 'json_object') {
+  generationConfig.responseMimeType = 'application/json';
+  const geminiExtra = (options.responseFormat as { _gemini?: { responseSchema?: Record<string, unknown> } })._gemini;
+  if (geminiExtra?.responseSchema) {
+    generationConfig.responseSchema = geminiExtra.responseSchema;
+  }
+}
+```
+
+- [ ] **Step 4.2: Tests**
+
+```ts
+// src/core/llm/providers/implementations/__tests__/GeminiProvider.structured.test.ts
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { GeminiProvider } from '../GeminiProvider.js';
+
+test('GeminiProvider: json_object + _gemini.responseSchema sets both responseMimeType and responseSchema', async () => {
+  // Stub fetch, capture generationConfig in the payload.
+  // Build options with responseFormat: { type: 'json_object', _gemini: { responseSchema: {...} } }.
+  // Assert generationConfig.responseMimeType === 'application/json'.
+  // Assert generationConfig.responseSchema is the passed schema.
+});
+
+test('GeminiProvider: bare json_object still works (no responseSchema)', async () => {
+  // Backward-compat: responseFormat = { type: 'json_object' } (no _gemini).
+  // Assert responseMimeType set, responseSchema NOT set.
+});
+```
+
+- [ ] **Step 4.3: Run + commit**
+
+```bash
+npx tsc --noEmit && npm test -- --grep "GeminiProvider" 2>&1 | tail -10
+perl -ne 'print "$ARGV:$.: $_" if /\x{2014}/' \
+  src/core/llm/providers/implementations/GeminiProvider.ts \
+  src/core/llm/providers/implementations/__tests__/GeminiProvider.structured.test.ts && echo clean
+git add src/core/llm/providers/implementations/GeminiProvider.ts \
+        src/core/llm/providers/implementations/__tests__/GeminiProvider.structured.test.ts
+git commit -m "feat(GeminiProvider): responseSchema for schema-enforced structured output
+
+Extends the existing responseFormat.type === 'json_object' branch to
+also set generationConfig.responseSchema when _gemini.responseSchema
+is present. Gemini enforces the schema via constrained decoding; the
+returned text is already valid JSON conforming to the schema.
+
+Backward compat: bare { type: 'json_object' } still works without the
+_gemini extra and only sets responseMimeType (the existing behavior)."
+```
+
+---
+
+## Task 5: OpenAIProvider passthrough test
+
+**Files:**
+- Modify: `src/core/llm/providers/implementations/__tests__/OpenAIProvider.test.ts` (or create the focused test if the existing file is too large)
+
+- [ ] **Step 5.1: Verify existing passthrough still works**
+
+OpenAIProvider already passes any `responseFormat` straight through to `payload.response_format` at line 662. No code change required. Add a test to lock the behavior so future refactors can't silently regress it:
+
+```ts
+test('OpenAIProvider: responseFormat with type=json_schema is passed verbatim to payload.response_format', async () => {
+  // Stub fetch, capture payload.
+  const rf = {
+    type: 'json_schema',
+    json_schema: { name: 'X', strict: true, schema: { type: 'object', properties: {} } },
+  };
+  // Call generateCompletion with options.responseFormat = rf.
+  // Assert payload.response_format === rf.
+});
+```
+
+- [ ] **Step 5.2: Run + commit**
+
+```bash
+npm test -- --grep "OpenAIProvider" 2>&1 | tail -10
+git add src/core/llm/providers/implementations/__tests__/OpenAIProvider.test.ts
+git commit -m "test(OpenAIProvider): lock json_schema responseFormat passthrough
+
+Existing OpenAIProvider.generateCompletion line 662 already passes any
+options.responseFormat straight to the OpenAI API as response_format.
+No code change. Adds a regression test that pins the json_schema shape
+so future refactors can't silently strip the structured-output payload."
+```
+
+---
+
+## Task 6: AgentSession.send overload + structured execution path
+
+**Files:**
+- Modify: `src/api/agent.ts`
+- Modify: `src/api/index.ts`
+- Create: `src/api/__tests__/agent.session.send.structured.test.ts`
+
+- [ ] **Step 6.1: Add new public types**
+
+In `src/api/agent.ts` (above the `AgentSession` interface):
+
+```ts
+import type { ZodType, z } from 'zod';
+
+export interface SessionSendOptions<S extends ZodType | undefined = undefined> {
+  /**
+   * Zod schema describing the expected shape of the assistant reply. When
+   * present, agentos converts the schema to JSON Schema, routes through
+   * the provider's native structured-output API, and returns a typed
+   * .object field on the result. Tools are disabled for the duration of
+   * a schema-aware call (see spec §3).
+   */
+  responseSchema?: S;
+  /**
+   * Display name for the schema in provider payloads (OpenAI's
+   * json_schema.name, Anthropic's tool name). Defaults to 'response'.
+   */
+  schemaName?: string;
+}
+
+export interface SessionSendStructuredResult<T> extends GenerateTextResult {
+  /** Zod-validated typed object. */
+  object: T;
+}
+```
+
+- [ ] **Step 6.2: Update the AgentSession interface with overload**
+
+```ts
+export interface AgentSession {
+  id: string;
+  send(input: MessageContent): Promise<GenerateTextResult>;
+  send<S extends ZodType>(
+    input: MessageContent,
+    opts: SessionSendOptions<S> & { responseSchema: S },
+  ): Promise<SessionSendStructuredResult<z.infer<S>>>;
+  stream(input: MessageContent): StreamTextResult;
+  messages(): Message[];
+  usage(): Promise<AgentOSUsageAggregate>;
+  clear(): void;
+}
+```
+
+- [ ] **Step 6.3: Update the implementation in `agent.ts:501`**
+
+Replace the existing `async send` method body with a single implementation that handles both branches:
+
+```ts
+async send(input: MessageContent, sendOpts?: SessionSendOptions<any>): Promise<any> {
+  const textForMemory = typeof input === 'string' ? input : extractTextFromContent(input);
+  const userMessage: Message = { role: 'user', content: input };
+  const requestMessages = useMemory ? [...history, userMessage] : [userMessage];
+
+  const responseFormat = sendOpts?.responseSchema
+    ? buildResponseFormat({
+        provider: resolveProviderId(baseOpts),
+        schema: sendOpts.responseSchema,
+        schemaName: sendOpts.schemaName ?? 'response',
+      })
+    : undefined;
+
+  const wrappedOpts = applyMemoryProvider(
+    {
+      ...baseOpts,
+      messages: requestMessages,
+      usageLedger: mergeUsageLedgerOptions(baseOpts.usageLedger, {
+        sessionId,
+        source: 'agent.session.send',
+      }),
+      ...(responseFormat ? { _responseFormat: responseFormat } : {}),
+    },
+    opts.memoryProvider,
+    textForMemory,
+  );
+
+  const result = await generateText(wrappedOpts as GenerateTextOptions);
+
+  let object: unknown = undefined;
+  if (sendOpts?.responseSchema) {
+    const text = result.text; // Anthropic forced-tool-use also surfaces input as text per Task 3
+    const parsed = JSON.parse(text);
+    const safe = sendOpts.responseSchema.safeParse(parsed);
+    if (!safe.success) {
+      throw new ObjectGenerationError(
+        'session.send: provider returned schema-enforced JSON that failed Zod validation',
+        { rawText: text, zodError: safe.error },
+      );
+    }
+    object = safe.data;
+  }
+
+  if (useMemory) {
+    history.push(userMessage);
+    history.push({ role: 'assistant', content: result.text });
+  }
+
+  return object !== undefined ? { ...result, object } : result;
+},
+```
+
+`resolveProviderId(baseOpts)` is a local helper (top of file):
+
+```ts
+function resolveProviderId(opts: { model?: string; provider?: string }): string {
+  if (opts.provider) return opts.provider;
+  if (typeof opts.model === 'string' && opts.model.includes(':')) {
+    return opts.model.split(':', 1)[0];
+  }
+  return 'openai'; // existing default
+}
+```
+
+`ObjectGenerationError` is imported from agentos's existing error module (used by `generateObject` already): `import { ObjectGenerationError } from '../core/validation/errors.js';` (or wherever it's currently re-exported from `@framers/agentos`).
+
+`buildResponseFormat` import from Task 1: `import { buildResponseFormat } from '../core/llm/providers/structuredOutputFormat.js';`.
+
+- [ ] **Step 6.4: Re-export new public types**
+
+In `src/api/index.ts` add:
+
+```ts
+export type { SessionSendOptions, SessionSendStructuredResult } from './agent.js';
+```
+
+(Or wherever existing AgentSession types are re-exported — match the existing convention.)
+
+- [ ] **Step 6.5: Tests**
+
+```ts
+// src/api/__tests__/agent.session.send.structured.test.ts
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { z } from 'zod';
+import { agent } from '../agent.js';
+// (Use the same stub-provider scaffolding the existing agent.session tests use.)
+
+const SimpleSchema = z.object({ verdict: z.string(), confidence: z.number().min(0).max(1) });
+
+test('session.send without responseSchema returns plain GenerateTextResult (regression guard)', async () => {
+  const a = agent({ model: 'openai:gpt-4o-mini', /* stub fetch */ });
+  const s = a.session();
+  const r = await s.send('hello');
+  assert.equal(typeof r.text, 'string');
+  assert.equal('object' in r, false);
+});
+
+test('session.send with responseSchema returns typed object alongside text', async () => {
+  // Stub generateText to return text='{"verdict":"yes","confidence":0.92}'.
+  const a = agent({ model: 'openai:gpt-4o-mini', /* stub */ });
+  const s = a.session();
+  const r = await s.send('decide', { responseSchema: SimpleSchema });
+  assert.equal(r.object.verdict, 'yes');
+  assert.equal(r.object.confidence, 0.92);
+  assert.equal(typeof r.text, 'string');
+});
+
+test('session memory survives a schema-aware send: messages() shows both turns', async () => {
+  // After the structured send above, s.messages() includes user 'decide' and assistant raw JSON.
+  // Verify the next send sees them as context (assert request payload includes prior messages).
+});
+
+test('schema validation failure throws ObjectGenerationError', async () => {
+  // Stub generateText to return text='{"verdict":"yes"}' (missing confidence).
+  // Assert thrown error is ObjectGenerationError with .zodError populated.
+});
+
+test('tools are not added when responseSchema is set', async () => {
+  // Stub generateText, capture wrappedOpts. Verify no tools field
+  // (or tools is empty) when responseSchema is in sendOpts and the
+  // caller didn't explicitly pass tools.
+});
+```
+
+- [ ] **Step 6.6: Run + em-dash sweep + commit**
+
+```bash
+npx tsc --noEmit && \
+  npm test 2>&1 | grep -E "^(ok|tests|pass|fail|skipped)" | tail -10 && \
+  perl -ne 'print "$ARGV:$.: $_" if /\x{2014}/' \
+    src/api/agent.ts src/api/index.ts \
+    src/api/__tests__/agent.session.send.structured.test.ts && echo clean
+git add src/api/agent.ts src/api/index.ts src/api/__tests__/agent.session.send.structured.test.ts
+git commit -m "feat(agent): session.send accepts responseSchema for typed structured output
+
+Extends AgentSession.send with an optional second parameter:
+
+  send<S extends ZodType>(
+    input: MessageContent,
+    opts: { responseSchema: S; schemaName?: string },
+  ): Promise<GenerateTextResult & { object: z.infer<S> }>
+
+When responseSchema is set:
+  1. Zod schema → JSON Schema via lowerZodToJsonSchema
+  2. Provider-specific payload via buildResponseFormat (Task 1)
+  3. Native structured-output enforcement at the provider call
+     (OpenAI json_schema, Anthropic forced tool_use, Gemini responseSchema)
+  4. Response text is parsed as JSON, validated against the Zod schema,
+     and returned as result.object
+  5. Session memory updates the same as the text path: user input and
+     assistant text both append to history; subsequent sends see them
+  6. ObjectGenerationError thrown if provider returns schema-enforced
+     JSON that still fails Zod validation (real bug, not retry-worthy)
+
+Backward compat: send(input) without options behaves identically to
+before. No changes to stream / messages / usage / clear.
+
+This is the agentos primitive paracosm's sendAndValidate has been
+emulating with a retry-with-feedback loop. paracosm migration to this
+API lands as a separate paracosm-track commit."
+```
+
+---
+
+## Task 7: Final verification (no commit)
+
+- [ ] **Step 7.1: Full type check**
+
+```bash
+cd /Users/johnn/Documents/git/voice-chat-assistant/packages/agentos
+npx tsc --noEmit
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 7.2: Full test suite**
+
+```bash
+npm test 2>&1 | grep -E "^(ok|tests|pass|fail|skipped)" | tail -5
+```
+
+Expected: existing-test-count + ~25 new tests, 0 fail.
+
+- [ ] **Step 7.3: Commit history review**
+
+```bash
+git log --oneline 9a907337..HEAD
+```
+
+Expected: 6 commits in this order:
+1. `feat(structured-output): provider-format adapter for session-aware schema enforcement`
+2. `chore(IProvider): tighten responseFormat type to admit json_schema shape`
+3. `feat(AnthropicProvider): forced tool-use for schema-enforced structured output`
+4. `feat(GeminiProvider): responseSchema for schema-enforced structured output`
+5. `test(OpenAIProvider): lock json_schema responseFormat passthrough`
+6. `feat(agent): session.send accepts responseSchema for typed structured output`
+
+- [ ] **Step 7.4: Em-dash sweep across all changed files**
+
+```bash
+perl -ne 'print "$ARGV:$.: $_" if /\x{2014}/' \
+  src/core/llm/providers/structuredOutputFormat.ts \
+  src/core/llm/providers/IProvider.ts \
+  src/core/llm/providers/implementations/AnthropicProvider.ts \
+  src/core/llm/providers/implementations/GeminiProvider.ts \
+  src/api/agent.ts src/api/index.ts \
+  src/core/llm/providers/__tests__/structuredOutputFormat.test.ts \
+  src/api/__tests__/agent.session.send.structured.test.ts \
+  src/core/llm/providers/implementations/__tests__/AnthropicProvider.structured.test.ts \
+  src/core/llm/providers/implementations/__tests__/GeminiProvider.structured.test.ts \
+  src/core/llm/providers/implementations/__tests__/OpenAIProvider.test.ts
+```
+
+Expected: no output.
+
+- [ ] **Step 7.5: Manual smoke against the new API**
+
+```ts
+import { agent } from '@framers/agentos';
+import { z } from 'zod';
+
+const a = agent({ model: 'openai:gpt-4o' });
+const s = a.session();
+const { object } = await s.send('Decide whether to ship: yes/no with confidence 0-1', {
+  responseSchema: z.object({ verdict: z.enum(['yes', 'no']), confidence: z.number() }),
+});
+console.log(object); // typed { verdict: 'yes' | 'no', confidence: number }
+```
+
+Run from a scratch script with a real `OPENAI_API_KEY`. Confirm typed object printed; no schema-fallback log lines emitted.
+
+---
+
+## Self-review
+
+- §4.1 spec types → Task 6.1 implementation. Match.
+- §4.2 spec impl → Task 6.3 implementation. Match.
+- §4.3 spec adapter → Task 1 implementation. Match.
+- §4.4 spec OpenAI passthrough → Task 5 (test only, code unchanged). Match.
+- §4.5 spec Anthropic forced tool-use → Task 3 implementation. Match.
+- §4.6 spec Gemini responseSchema → Task 4 implementation. Match.
+- §4.7 spec tests → split across Tasks 1, 3, 4, 5, 6. Match.
+- §5 spec risks → Task 6 throws on Zod failure (risk #1, #4); Task 1 sanitizes name (impl detail).
+- §6 spec execution order → matches Task 1-6 numbering.
+
+No placeholder strings; all `<TBD>` placeholders eliminated. Type names consistent across tasks: `SessionSendOptions`, `SessionSendStructuredResult`, `BuildResponseFormatInput`, `_agentosUseToolForStructuredOutput`.
+
+---
+
+## Execution handoff
+
+Use `superpowers:executing-plans` to implement task-by-task. Per agentos repo convention (master branch only, push only on user request), commit per task per plan; push after Task 7 verification with explicit user approval.

--- a/docs/superpowers/specs/2026-04-26-session-structured-output-design.md
+++ b/docs/superpowers/specs/2026-04-26-session-structured-output-design.md
@@ -1,0 +1,365 @@
+# Session-aware structured output for `agent.session.send()`
+
+**Authored:** 2026-04-26.
+**Author:** paracosm-track. **Paired plan:** `docs/superpowers/plans/2026-04-26-session-structured-output-plan.md`.
+
+---
+
+## §1. Problem
+
+`agent.session.send(input)` is the agentos primitive for stateful conversational LLM calls. It accumulates a per-session message history and routes through `generateText` to the configured provider. Today it is a text-in / text-out function: the schema of the assistant reply is the model's responsibility alone.
+
+Downstream callers that need a typed object (paracosm `commander`, `department`, `judge`, plus any future agentos consumer) wrap `session.send` with a retry-with-feedback loop, validate against a Zod schema, push corrective user turns when validation fails, and fall back after N attempts. paracosm's [`runtime/llm-invocations/sendAndValidate.ts`](https://github.com/framersai/paracosm/blob/master/src/runtime/llm-invocations/sendAndValidate.ts) is one such wrapper. The fallback path produces visible artifacts like `decision: "Commander decision unavailable; defer to department consensus."` whenever the model fails 3 attempts at producing schema-valid JSON. Real prod recordings of `paracosm.agentos.sh` show this happening on `gpt-5.4-mini` for a 10-field nested-array schema, repeatedly.
+
+The retry-with-feedback approach predates GA structured outputs across providers. Today every relevant provider either (a) supports native JSON-Schema enforcement (OpenAI `response_format: { type: 'json_schema' }`) or (b) supports forced tool-use that achieves the same guarantee (Anthropic `tool_choice: { type: 'tool', name }`) or (c) supports a constrained-decoding equivalent (Gemini `responseSchema` + `responseMimeType: 'application/json'`). agentos already plumbs the OpenAI shape through `generateText._responseFormat` to `OpenAIProvider.generateCompletion`, but only for `generateObject` (a one-shot API that discards session memory). The same bytes are not exposed to `session.send`.
+
+The result is paracosm and other agentos consumers run a retry loop that the underlying providers can eliminate at the API call.
+
+## §2. Goals
+
+1. Add an optional `responseSchema` parameter to `AgentSession.send()` that accepts a Zod schema.
+2. When `responseSchema` is set, route through the provider's native structured-output API:
+   - OpenAI: `response_format: { type: 'json_schema', json_schema: { name, strict: true, schema } }`
+   - Anthropic: forced tool_use with `tools: [{ name, input_schema }]` and `tool_choice: { type: 'tool', name }`
+   - Gemini: `responseMimeType: 'application/json'` + `responseSchema: <jsonSchema>`
+3. Preserve session memory: the user message + the assistant's structured response both append to history, just as in the text-only path. A subsequent `session.send` call sees the prior structured output as part of its context.
+4. Return a typed result object: when `responseSchema` is set, the `GenerateTextResult` extension includes a typed `.object: z.infer<T>` field. The raw `.text` field still carries the JSON string for debugging.
+5. Backward compatible: every existing `session.send(input)` call (no schema) keeps its current behavior. No rename, no breaking change to the return type for the default overload.
+6. Where a provider doesn't support strict JSON-Schema enforcement, degrade gracefully to its best available mode (e.g. OpenRouter falls back to `json_object`); never silently call without any constraint.
+
+## §3. Out of scope
+
+- Streaming structured output. `session.stream` is not extended in this spec; the schema-aware path is non-streaming on first ship. A follow-up adds streaming if a real consumer asks.
+- Replacing `generateObject`. It stays as the one-shot, no-session API. Many callers use it that way and the path is well-tested. Schema-aware `session.send` is the new option for callers that need both schema enforcement AND session memory.
+- Migrating paracosm's `sendAndValidate`. That migration is queued as a follow-up paracosm spec; this spec only adds the agentos primitive.
+- Auto-retry on provider-side errors (rate-limit / 5xx). Existing retry/backoff in agentos providers continues to apply; the schema-validation retry loop becomes dead code when native enforcement is on.
+- Tool calling alongside `responseSchema`. When a schema is set, tools are disabled for that call; mixing both requires a different API shape (e.g. multi-turn function-call loops) and is out of scope.
+
+## §4. Implementation
+
+### §4.1 New types
+
+`packages/agentos/src/api/agent.ts` (extend the existing types):
+
+```ts
+import type { ZodType, z } from 'zod';
+
+/** Options for a single session.send call. */
+export interface SessionSendOptions<S extends ZodType | undefined = undefined> {
+  /**
+   * Zod schema describing the expected shape of the assistant reply. When
+   * present, agentos converts the schema to JSON Schema, routes through
+   * the provider's native structured-output API (OpenAI json_schema,
+   * Anthropic forced tool_use, Gemini responseSchema), and returns a typed
+   * .object field on the result.
+   *
+   * Tools are disabled for the duration of a schema-aware call; see §3.
+   */
+  responseSchema?: S;
+  /**
+   * Display name for the schema in provider payloads. Surfaces in OpenAI's
+   * json_schema.name and Anthropic's tool name. Defaults to 'response'.
+   */
+  schemaName?: string;
+}
+
+/** Typed result returned when responseSchema is set. */
+export interface SessionSendStructuredResult<T> extends GenerateTextResult {
+  /** The Zod-validated object, typed via z.infer. */
+  object: T;
+}
+```
+
+The session interface adds an overload:
+
+```ts
+export interface AgentSession {
+  send(input: MessageContent): Promise<GenerateTextResult>;
+  send<S extends ZodType>(
+    input: MessageContent,
+    opts: SessionSendOptions<S>,
+  ): Promise<SessionSendStructuredResult<z.infer<S>>>;
+  // ... existing stream / messages / usage / clear methods unchanged
+}
+```
+
+### §4.2 `session.send` implementation
+
+Modify the implementation at `packages/agentos/src/api/agent.ts:501`:
+
+```ts
+async send<S extends ZodType | undefined = undefined>(
+  input: MessageContent,
+  sendOpts?: SessionSendOptions<S>,
+): Promise<S extends ZodType ? SessionSendStructuredResult<z.infer<S>> : GenerateTextResult> {
+  const textForMemory = typeof input === 'string' ? input : extractTextFromContent(input);
+  const userMessage: Message = { role: 'user', content: input };
+  const requestMessages = useMemory ? [...history, userMessage] : [userMessage];
+
+  // Resolve provider-specific structured-output payload when a schema is set.
+  const responseFormat = sendOpts?.responseSchema
+    ? buildResponseFormat({
+        provider: resolveProviderId(baseOpts),
+        schema: sendOpts.responseSchema,
+        schemaName: sendOpts.schemaName ?? 'response',
+      })
+    : undefined;
+
+  const wrappedOpts = applyMemoryProvider(
+    {
+      ...baseOpts,
+      messages: requestMessages,
+      usageLedger: mergeUsageLedgerOptions(baseOpts.usageLedger, {
+        sessionId,
+        source: 'agent.session.send',
+      }),
+      ...(responseFormat ? { _responseFormat: responseFormat } : {}),
+    },
+    opts.memoryProvider,
+    textForMemory,
+  );
+
+  const result = await generateText(wrappedOpts as GenerateTextOptions);
+
+  // Parse + validate when a schema was supplied. Throws on validation
+  // failure rather than retrying — native enforcement guarantees a valid
+  // shape on every successful response, so a parse failure here is a real
+  // bug (provider returned a malformed payload despite enforcement).
+  let object: z.infer<NonNullable<S>> | undefined;
+  if (sendOpts?.responseSchema) {
+    const text = extractStructuredOutputText(result, resolveProviderId(baseOpts));
+    const parsed = JSON.parse(text);
+    const safe = sendOpts.responseSchema.safeParse(parsed);
+    if (!safe.success) {
+      throw new ObjectGenerationError(
+        'session.send: provider returned schema-enforced JSON that failed Zod validation',
+        { rawText: text, zodError: safe.error },
+      );
+    }
+    object = safe.data;
+  }
+
+  if (useMemory) {
+    history.push(userMessage);
+    history.push({ role: 'assistant', content: result.text });
+  }
+
+  return (object !== undefined
+    ? ({ ...result, object } as SessionSendStructuredResult<z.infer<NonNullable<S>>>)
+    : result) as any;
+},
+```
+
+`resolveProviderId(baseOpts)` is a new local helper that reads the resolved provider from `baseOpts.model` (already a `'provider:model'` string today). `extractStructuredOutputText` is a small helper that pulls the JSON string out of the provider response: for OpenAI/Gemini it's just `result.text`; for Anthropic with forced tool_use the JSON is in the `tool_use` content block's `input` field, requiring shape inspection.
+
+### §4.3 Provider-format adapter
+
+New file `packages/agentos/src/core/llm/providers/structuredOutputFormat.ts`:
+
+```ts
+import type { ZodType } from 'zod';
+import { lowerZodToJsonSchema } from '../../../orchestration/compiler/SchemaLowering.js';
+
+/**
+ * Build a provider-specific structured-output payload from a Zod schema.
+ * Returns the object that agentos plumbs through GenerateTextOptions._responseFormat
+ * to the underlying provider.generateCompletion call.
+ *
+ * Provider matrix (April 2026):
+ *   - openai     →  { type: 'json_schema', json_schema: { name, strict: true, schema } }
+ *   - anthropic  →  { _agentosUseToolForStructuredOutput: true, tool: { name, input_schema } }
+ *                    AnthropicProvider routes this to tools + tool_choice forced.
+ *   - gemini     →  { type: 'json_object', _gemini: { responseSchema } }
+ *                    GeminiProvider already maps json_object → responseMimeType; the
+ *                    extra _gemini field tells it to also set responseSchema.
+ *   - openrouter →  { type: 'json_object' }
+ *                    OpenRouter currently exposes json_object only; degrade.
+ *   - default    →  { type: 'json_object' }
+ *                    Best-effort for unknown providers.
+ */
+export interface BuildResponseFormatInput {
+  provider: string;
+  schema: ZodType;
+  schemaName: string;
+}
+
+export function buildResponseFormat(
+  input: BuildResponseFormatInput,
+): Record<string, unknown> {
+  const jsonSchema = lowerZodToJsonSchema(input.schema);
+  const schemaName = input.schemaName.replace(/[^a-zA-Z0-9_]/g, '_').slice(0, 64);
+
+  switch (input.provider) {
+    case 'openai':
+      return {
+        type: 'json_schema',
+        json_schema: {
+          name: schemaName,
+          strict: true,
+          schema: jsonSchema,
+        },
+      };
+    case 'anthropic':
+      return {
+        _agentosUseToolForStructuredOutput: true,
+        tool: { name: schemaName, input_schema: jsonSchema },
+      };
+    case 'gemini':
+    case 'gemini-cli':
+      return {
+        type: 'json_object',
+        _gemini: { responseSchema: jsonSchema },
+      };
+    case 'openrouter':
+    default:
+      return { type: 'json_object' };
+  }
+}
+```
+
+The adapter is intentionally thin: each provider's `generateCompletion` keeps the full shape-translation logic local to that provider (§4.4-§4.6), preserving the layering already in agentos.
+
+### §4.4 OpenAIProvider
+
+OpenAI is already complete. Existing logic at [`OpenAIProvider.ts:662`](src/core/llm/providers/implementations/OpenAIProvider.ts#L662) already does:
+
+```ts
+if (options.responseFormat !== undefined) payload.response_format = options.responseFormat;
+```
+
+This passes the `{ type: 'json_schema', json_schema: { name, strict, schema } }` object straight to the OpenAI API. The API enforces schema on output. No change needed.
+
+The only correction: tighten the type of `IProvider.responseFormat` from `{ type: 'text' | 'json_object' | string }` to also accept the json_schema shape:
+
+```ts
+// IProvider.ts (line ~137)
+responseFormat?:
+  | { type: 'text' | 'json_object' }
+  | { type: 'json_schema'; json_schema: { name: string; strict: boolean; schema: Record<string, unknown> } }
+  | Record<string, unknown>;
+```
+
+Plus tests added per §4.7.
+
+### §4.5 AnthropicProvider
+
+Anthropic doesn't have a `response_format` field. The structured-output equivalent is forced tool-use: declare a single `output` tool with the schema as `input_schema`, then set `tool_choice: { type: 'tool', name: 'output' }`. The model is forced to call that tool with input matching the schema; the JSON-validated input is in the response's `tool_use` block.
+
+Modify `AnthropicProvider.generateCompletion` (around line 848 where `tool_choice` is already built):
+
+```ts
+// Detect schema-driven structured output and route to forced tool_use.
+if (options.responseFormat
+  && (options.responseFormat as any)._agentosUseToolForStructuredOutput
+) {
+  const sf = options.responseFormat as { tool: { name: string; input_schema: Record<string, unknown> } };
+  payload.tools = [
+    { name: sf.tool.name, input_schema: sf.tool.input_schema },
+    ...(payload.tools ?? []),
+  ];
+  payload.tool_choice = { type: 'tool', name: sf.tool.name };
+}
+```
+
+After response, in the response-mapping path (already exists for tool_use blocks), surface the matching block's `input` field as a JSON string in the resulting `text` so generateText callers see a JSON-string body even though the underlying mechanism is tool_use. This keeps `result.text` semantics consistent across providers and lets `session.send`'s `extractStructuredOutputText` helper (§4.2) just `JSON.stringify(toolUseBlock.input)`.
+
+Concretely: Anthropic returns content blocks; the existing mapping at AnthropicProvider already handles tool_use. We add a line that looks for the matching tool_use block by name and writes its `JSON.stringify(input)` as the `text` of the response when forced-tool-use mode is active.
+
+### §4.6 GeminiProvider
+
+Gemini already maps `responseFormat.type === 'json_object'` to `responseMimeType: 'application/json'` ([GeminiProvider.ts:732](src/core/llm/providers/implementations/GeminiProvider.ts#L732)). Extend that branch to also set `responseSchema` when present:
+
+```ts
+if (options.responseFormat?.type === 'json_object') {
+  generationConfig.responseMimeType = 'application/json';
+  const geminiExtra = (options.responseFormat as any)._gemini;
+  if (geminiExtra?.responseSchema) {
+    generationConfig.responseSchema = geminiExtra.responseSchema;
+  }
+}
+```
+
+Gemini's structured-output enforcement is constraint-decoding; the model output text is already JSON.
+
+### §4.7 Tests
+
+`packages/agentos/src/api/__tests__/agent.session.send.structured.test.ts` (new):
+
+- send(prompt, { responseSchema }) with a stub OpenAI invoker returning a valid JSON payload that matches: returns `{ ..., object: parsed }` with correct types.
+- send(prompt) without options: behaves identically to before, returns plain `GenerateTextResult` (regression guard).
+- session memory survives a structured call: `messages()` after a structured send shows user + assistant entries; the subsequent send sees them as context.
+- ZodError is thrown when the provider returns malformed JSON despite enforcement (forced via stub).
+- Tools are skipped when `responseSchema` is set (assertion that `payload.tools` is not added).
+
+`packages/agentos/src/core/llm/providers/__tests__/structuredOutputFormat.test.ts` (new):
+
+- `buildResponseFormat({ provider: 'openai', schema: ZodObj, schemaName: 'X' })` returns `{ type: 'json_schema', json_schema: { name: 'X', strict: true, schema } }`.
+- Anthropic returns the `_agentosUseToolForStructuredOutput: true, tool: { name, input_schema }` shape.
+- Gemini returns `{ type: 'json_object', _gemini: { responseSchema } }`.
+- Unknown provider returns `{ type: 'json_object' }` (degrade).
+- `schemaName` characters are sanitized: dots / slashes / spaces replaced with underscores; >64 chars truncated.
+
+`packages/agentos/src/core/llm/providers/implementations/__tests__/AnthropicProvider.structured.test.ts` (new):
+
+- generateCompletion with `responseFormat._agentosUseToolForStructuredOutput` adds the forced tool + tool_choice into the payload.
+- Response mapping picks up the matching tool_use block and writes `JSON.stringify(input)` as the `text` field.
+
+`packages/agentos/src/core/llm/providers/implementations/__tests__/GeminiProvider.structured.test.ts` (new):
+
+- generateCompletion with `responseFormat: { type: 'json_object', _gemini: { responseSchema } }` sets both `responseMimeType` and `responseSchema` on `generationConfig`.
+
+`packages/agentos/src/core/llm/providers/implementations/__tests__/OpenAIProvider.structured.test.ts` (extend existing test file):
+
+- generateCompletion with `responseFormat: { type: 'json_schema', json_schema: { ... } }` passes the entire object as `payload.response_format`.
+
+## §5. Risks + mitigations
+
+1. **Provider-side schema enforcement is not bug-for-bug identical across vendors.** OpenAI's strict json_schema rejects unknown fields; Anthropic's tool_use is permissive; Gemini's responseSchema currently has feature gaps (refs, oneOf). Mitigation: the spec calls out one path per provider and the per-provider test suite (§4.7) pins the exact shape we send. Where a provider chokes on a sub-feature of JSON Schema, callers see a clear provider error, not a silent fallback.
+2. **`lowerZodToJsonSchema` may emit JSON Schema constructs that one provider supports and another doesn't** (e.g., `additionalProperties`, `oneOf`). Mitigation: existing orchestration graph compiler already uses this lowering against all providers; downstream issues surface in tests rather than at runtime. Schema authors keep schemas conservative.
+3. **Tools are disabled when `responseSchema` is set.** A future caller may want both. Mitigation: documented in §3 and in the new `SessionSendOptions` JSDoc; a follow-up spec extends to a multi-turn schema+tool-loop pattern.
+4. **OpenRouter has no schema enforcement available.** Mitigation: degrades to `json_object` (the model is asked for JSON but the schema is not enforced). Caller-side validation still runs (`safeParse`); fails fast on invalid output rather than retry. Documented in §4.3 default branch.
+5. **Existing callers passing `_responseFormat: { type: 'json_object' }` (e.g. `generateObject`) keep working.** The new code paths only trigger when `responseSchema` is set on `session.send`. Mitigation: explicit branch on the new `_agentosUseToolForStructuredOutput` flag for Anthropic; OpenAI's `response_format` passthrough still accepts `json_object`.
+6. **Concurrent-session-work in working tree.** agentos has uncommitted changes in `src/emergent/`, `src/memory/`, etc. None overlap the files this spec touches. Mitigation: the surgical-stage pattern (HEAD-clean diff applied via `git apply --cached`) used by paracosm-track is also valid here; the plan calls it out in §6.
+
+## §6. Execution order
+
+Each step ends with `npm test` from `packages/agentos/` (full suite) and a commit. Push happens on user request after all commits land.
+
+1. Add `lowerZodToJsonSchema` import path verification + new file `structuredOutputFormat.ts` with full provider-matrix function. Tests in §4.7. Run; expect existing suite + new tests pass.
+2. Tighten `IProvider.responseFormat` type to accept the `json_schema` shape (no behavior change; type-only). Existing tests pass; type-check the workspace.
+3. Add `_agentosUseToolForStructuredOutput` branch to `AnthropicProvider.generateCompletion` request build + response mapping. Tests added per §4.7. Existing Anthropic tests still pass.
+4. Add `_gemini.responseSchema` branch to `GeminiProvider`. Tests per §4.7.
+5. Add `OpenAIProvider` structured-output test (§4.7). No code change.
+6. Extend `AgentSession.send` signature + implementation per §4.1-§4.2. Add overload typing. Tests per §4.7. Verify `messages()` shows the structured assistant entry.
+7. Em-dash sweep across all changed files. Per project rule (no em-dashes in agentos code or docs).
+8. Final type check: `npx tsc --noEmit`. Final test: full agentos suite pass.
+
+## §7. Success criteria
+
+- Backward compat: every existing `session.send(input)` call returns the same shape (regression test in §4.7).
+- New: `session.send(input, { responseSchema })` returns `{ ..., object: T }` with T inferred from the Zod schema.
+- Provider matrix tests (§4.7) pass for OpenAI / Anthropic / Gemini / fallback.
+- Session memory verified: after a structured send, `messages()` returns the user + assistant entries; the next send sees them.
+- `npx tsc --noEmit` clean.
+- Em-dash sweep clean.
+- agentos npm package version bumps appropriately (minor: new public API).
+
+## §8. References
+
+- [packages/agentos/src/api/agent.ts:501](src/api/agent.ts#L501) — `AgentSession.send` impl (text-only path)
+- [packages/agentos/src/api/generateText.ts:338](src/api/generateText.ts#L338) — `GenerateTextOptions._responseFormat`
+- [packages/agentos/src/api/generateText.ts:931](src/api/generateText.ts#L931) — `_responseFormat → provider responseFormat` plumbing
+- [packages/agentos/src/api/generateObject.ts:419](src/api/generateObject.ts#L419) — existing `json_object` usage (one-shot, no session memory)
+- [packages/agentos/src/core/llm/providers/IProvider.ts:137](src/core/llm/providers/IProvider.ts#L137) — `responseFormat` type definition
+- [packages/agentos/src/core/llm/providers/implementations/OpenAIProvider.ts:662](src/core/llm/providers/implementations/OpenAIProvider.ts#L662) — passthrough
+- [packages/agentos/src/core/llm/providers/implementations/AnthropicProvider.ts:848](src/core/llm/providers/implementations/AnthropicProvider.ts#L848) — `tool_choice` build
+- [packages/agentos/src/core/llm/providers/implementations/GeminiProvider.ts:732](src/core/llm/providers/implementations/GeminiProvider.ts#L732) — `responseMimeType` mapping
+- [packages/agentos/src/orchestration/compiler/SchemaLowering.ts:38](src/orchestration/compiler/SchemaLowering.ts#L38) — `lowerZodToJsonSchema`
+- paracosm consumer waiting on this primitive: [paracosm/src/runtime/llm-invocations/sendAndValidate.ts](https://github.com/framersai/paracosm/blob/master/src/runtime/llm-invocations/sendAndValidate.ts)
+
+## §9. Glossary
+
+- **Structured output:** the provider-level mechanism that forces the model's reply to conform to a schema. OpenAI calls this `response_format: { type: 'json_schema' }`; Anthropic uses forced tool-use; Gemini uses `responseSchema`.
+- **Session memory:** the conversation history accumulated by `AgentSession`. Each `send` call appends user + assistant messages to the history; subsequent calls include the history as messages context.
+- **Schema-aware send:** a `session.send` invocation with `responseSchema` set. Returns a typed object validated against the schema; raw JSON is also available on `.text`.
+- **`generateObject`:** existing one-shot agentos primitive. Sets `_responseFormat: { type: 'json_object' }` and runs no session memory. Coexists with this spec.


### PR DESCRIPTION
Two-file pair documenting the design and implementation of an optional responseSchema parameter on AgentSession.send that routes through each provider's native structured-output API while preserving session memory:

  - OpenAI:    response_format: { type: 'json_schema', json_schema: { ... } }
  - Anthropic: forced tool-use (single tool with input_schema, tool_choice forced)
  - Gemini:    responseMimeType + responseSchema in generationConfig
  - OpenRouter / unknown: degrades to json_object (no schema enforcement)

Existing agentos plumbing already partially in place: generateText already passes _responseFormat through to providers, OpenAIProvider already forwards the OpenAI shape verbatim (line 662), AnthropicProvider already builds tool_choice (line 848), GeminiProvider already maps json_object to responseMimeType (line 732). What's missing is exposing this on session.send (currently text-only) plus per-provider routing of schema-bearing payloads.

Motivation: paracosm's commander/department/judge calls fail schema validation 3x in a row on gpt-5.4-mini and fall back to the literal "Commander decision unavailable; defer to department consensus" text in stored artifacts. With native enforcement the retry loop becomes dead code.

Plan is 6 tasks + verification, ~315 lines of source + tests across 5 files, fully backward-compatible. No breaking change to any existing API.

## Summary
- What does this PR change?
- Why is this change needed?

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (README or typedoc)
- [ ] Conventional commit title/body

## Related
Fixes # (issue)

## Summary by Sourcery

Document the design and implementation plan for adding session-aware structured output to agent.session.send, enabling schema-enforced, provider-native structured responses while preserving session memory.

Documentation:
- Add a design spec describing how agent.session.send will accept a Zod response schema and route it through provider-native structured output mechanisms for OpenAI, Anthropic, Gemini, and fallbacks.
- Add an implementation plan detailing the new adapter, provider-specific handling, API overloads, testing strategy, and rollout steps for session-aware structured output in agent.session.send.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive implementation plan for session-aware structured output with provider-native support (OpenAI, Anthropic, Gemini), Zod schema validation, and memory persistence across requests
  * Added design specification detailing API extensions for optional response schemas, typed object parsing, and intelligent routing across multiple AI providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->