### PR TITLE
fix(generate-text): document auto-fallback default; flag strict mode …

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,40 @@ const { text: claude } = await generateText({
 });
 ```
 
-16 providers. Provider fallback is opt-in via `fallbackProviders`:
+16 providers, automatic fallback. When the primary provider returns a retryable error (HTTP 402/429/5xx, network failures, auth issues), `generateText` walks the canonical fallback chain for that provider using whichever API keys are present in the environment — no extra imports, no chain construction needed:
 
 ```typescript
-import { buildFallbackChain, generateText } from '@framers/agentos';
+import { generateText } from '@framers/agentos';
 
 const { text } = await generateText({
   provider: 'anthropic',
   prompt: 'Compare TCP and UDP.',
-  fallbackProviders: buildFallbackChain('anthropic'),
+});
+// Anthropic primary, falls through to OpenAI / Gemini / OpenRouter / etc. on retryable errors
+```
+
+Want strict single-provider routing (e.g. for billing isolation, capability auditing, or provider-pinned tests)? Pass an empty array to opt out:
+
+```typescript
+const { text } = await generateText({
+  provider: 'anthropic',
+  prompt: 'Compare TCP and UDP.',
+  fallbackProviders: [], // strict mode — fail if Anthropic is unavailable
+});
+```
+
+Or supply your own chain (and import `buildFallbackChain` only if you want to derive a default chain to splice from):
+
+```typescript
+import { generateText, buildFallbackChain } from '@framers/agentos';
+
+const { text } = await generateText({
+  provider: 'anthropic',
+  prompt: 'Compare TCP and UDP.',
+  fallbackProviders: [
+    { provider: 'openai', model: 'gpt-4o-mini' },
+    { provider: 'openrouter' },
+  ],
 });
 ```
 

--- a/src/api/agent.ts
+++ b/src/api/agent.ts
@@ -105,8 +105,11 @@ export interface AgentOptions extends BaseAgentConfig {
    * Ordered list of fallback providers to try when the primary provider
    * fails with a retryable error (HTTP 402/429/5xx, network errors).
    *
-   * Applied to every `generate()`, `stream()`, and `session.send()` /
-   * `session.stream()` call made through this agent.
+   * **Defaults to auto-built chain** when omitted — fallback is on by
+   * default. Pass `[]` for strict single-provider mode, or supply a
+   * custom array to control the chain. Applied to every `generate()`,
+   * `stream()`, and `session.send()` / `session.stream()` call made
+   * through this agent.
    *
    * @see {@link GenerateTextOptions.fallbackProviders}
    */

--- a/src/api/generateText.ts
+++ b/src/api/generateText.ts
@@ -269,14 +269,41 @@ export interface GenerateTextOptions {
    * Ordered list of fallback providers to try when the primary provider fails
    * with a retryable error (HTTP 402/429/5xx, network errors, auth failures).
    *
-   * Each entry specifies a provider and an optional model override.  When the
-   * model is omitted, the provider's default text model (from
-   * {@link PROVIDER_DEFAULTS}) is used.
+   * **Default behavior (omit / `undefined`):** auto-build the canonical
+   * fallback chain for the primary provider via {@link buildFallbackChain},
+   * filtered to providers that have API keys present in the environment.
+   * No import needed — fallback is on by default.
    *
-   * Providers are tried left-to-right; the first successful response wins.
-   * When all fallbacks are exhausted, the last error is re-thrown.
+   * **Strict mode (`[]`):** explicitly opt out of fallback. The primary
+   * provider's error is re-thrown after exhausting any provider-internal
+   * retries. Use this when billing isolation, capability auditing, or
+   * provider-pinned testing requires a single-provider guarantee.
    *
-   * @example
+   * **Custom chain (array of entries):** specify exactly which providers
+   * (and optional model overrides) to try, in order. Each entry's model
+   * defaults to the provider's text-generation default from
+   * {@link PROVIDER_DEFAULTS} when omitted. Providers are tried
+   * left-to-right; the first successful response wins.
+   *
+   * @example Default — auto-fallback through the canonical chain
+   * ```ts
+   * const result = await generateText({
+   *   provider: 'anthropic',
+   *   prompt: 'Hello',
+   * });
+   * // On retryable Anthropic failure, walks anthropic → openai → gemini → ...
+   * ```
+   *
+   * @example Strict mode — fail if the primary is unavailable
+   * ```ts
+   * const result = await generateText({
+   *   provider: 'anthropic',
+   *   prompt: 'Hello',
+   *   fallbackProviders: [],
+   * });
+   * ```
+   *
+   * @example Custom chain
    * ```ts
    * const result = await generateText({
    *   provider: 'anthropic',


### PR DESCRIPTION
…opt-out

The generateText / streamText / agent implementations already auto-build the canonical fallback chain when fallbackProviders is omitted (see generateText.ts:1163 and streamText.ts:624). The README + JSDoc claimed fallback was opt-in via buildFallbackChain, which forced consumers to add a redundant import + call to get the same behavior.

Updates:
- README.md: rewrites the "16 providers" section to lead with the zero-import default; documents fallbackProviders: [] as strict mode; keeps the buildFallbackChain example only for the custom-chain case
- generateText.ts (GenerateTextOptions.fallbackProviders): JSDoc spells out the three modes (omit -> auto, [] -> strict, array -> custom) with concrete @example blocks for each
- agent.ts (AgentSessionOptions.fallbackProviders): same fix mirrored for the agent surface; preserves @see link to GenerateTextOptions

No runtime change. Consumers who already omit fallbackProviders see no behavior diff; the docs now match the code.

## Summary
- What does this PR change?
- Why is this change needed?

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (README or typedoc)
- [ ] Conventional commit title/body

## Related
Fixes # (issue)

## Summary by Sourcery

Document the default automatic provider fallback behavior and strict mode opt-out for text generation and agents so that documentation matches existing runtime behavior.

Enhancements:
- Expand JSDoc for GenerateTextOptions.fallbackProviders and AgentOptions.fallbackProviders to describe default auto-fallback, strict mode, and custom chains with concrete examples.

Documentation:
- Clarify that generateText uses automatic provider fallback by default and document strict mode via fallbackProviders: [] and custom chains in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to explain automatic provider fallback behavior when primary provider encounters retryable errors (HTTP 402/429/5xx, network failures, auth issues)
  * Added examples showing how to disable fallback with an empty array configuration
  * Added examples for customizing the fallback chain with explicit provider selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->